### PR TITLE
Added functionality to support oneshot mangas

### DIFF
--- a/src/connection.rs
+++ b/src/connection.rs
@@ -1,22 +1,97 @@
 //! This module is concerned with making asynchronous
 //! requests.
+extern crate reqwest;
+extern crate tokio;
+extern crate futures;
+extern crate serde;
 
-use reqwest;
 use tokio::task::{self, JoinHandle};
 use futures::future::join_all;
+use serde::{Serialize, Deserialize};
+use std::time::Instant;
 
 use crate::manga::MangaImage;
 
+/// A struct for containing the report POST request
+#[derive(Serialize, Deserialize)]
+struct ResponseBody {
+    pub url: String,
+    pub success: bool,
+    pub cached: bool,
+    pub bytes: usize,
+    pub duration: u128
+}
+
 /// Makes a get request to fetch an image asynchronously
-async fn async_get_image(url: String, page_no: i32) -> Result<MangaImage, Box<dyn std::error::Error + Send + Sync>> {
+async fn async_get_image(url: String, page_no: i32, report: bool) -> Result<MangaImage, Box<dyn std::error::Error + Send + Sync>> {
+    let url_clone = url.clone();
+
+    let start_time = Instant::now();
     let res = reqwest::get(url)
-        .await?
-        .bytes()
+        .await?;
+    let elapsed_time = start_time.elapsed().as_millis();
+
+    let headers = res.headers();
+    let cache = headers.get("x-cache")
+        .unwrap()
+        .to_str()
+        .unwrap_or("MISS");
+
+    let mut cache_state = false; 
+    if (cache == "HIT") {
+        cache_state = true;
+    }
+
+    let content_length = headers.get("content-length")
+        .unwrap()
+        .to_str()
+        .unwrap_or("0");
+    let content_length = content_length.parse::<usize>().unwrap();
+
+    if (!res.status().is_success() && report) {
+        async_report(url_clone, false, cache_state, content_length, elapsed_time)
+            .await?;
+        panic!("Failed to retrieve image!"); // TODO: Use ERR or retry instead
+    }
+
+    let image_bytes = res.bytes().await?;
+    let image = image::load_from_memory(&image_bytes)?;
+    let image = MangaImage::new(page_no, image);
+
+    if (report) {
+        async_report(url_clone, true, cache_state, content_length, elapsed_time).await?;
+    }
+    
+    Ok(image)
+}
+
+/// Reports back to the MangaDex@Home server
+/// TODO: FIX CAPTCHA. CAPTCHA reply not yet working
+async fn async_report(url: String, success: bool, cached: bool, bytes: usize, duration: u128) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+    let client = reqwest::Client::new();
+
+    let body = ResponseBody {url, success, cached, bytes, duration};
+
+    let res = client.post("https://api.mangadex.org/report")
+        .json(&body)
+        .send()
         .await?;
     
-    let image = image::load_from_memory(&res)?;
-    let image = MangaImage::new(page_no, image);
-    Ok(image)
+    if (res.status().as_u16() == 412) {
+        let res_headers = res.headers();
+        let captcha_ans = res_headers.get("X-Captcha-Sitekey")
+            .unwrap()
+            .to_str()
+            .expect("Cannot get captcha answer");
+        
+        let cap_res = client.post("https://api.mangadex.org/report")
+            .header("X-Captcha-Result", captcha_ans)
+            .json(&body)
+            .send()
+            .await?;
+    }
+
+    Ok(())
 }
 
 /// Makes multiple get requests to fetch multiple images
@@ -35,7 +110,7 @@ pub async fn async_get_image_batch(batch: &mut Vec<String>, concurrent_process :
             match batch.pop() {
                 Some(url) => {
                     let page_no : i32 = i as i32 + j;
-                    handle_vec.push(task::spawn(async_get_image(url, page_no)));
+                    handle_vec.push(task::spawn(async_get_image(url, page_no, false)));
                 },
                 None => (),
             }

--- a/src/connection.rs
+++ b/src/connection.rs
@@ -23,7 +23,7 @@ struct ResponseBody {
 }
 
 /// Makes a get request to fetch an image asynchronously
-async fn async_get_image(url: String, page_no: i32, report: bool) -> Result<MangaImage, Box<dyn std::error::Error + Send + Sync>> {
+pub async fn async_get_image(url: String, page_no: i32, report: bool) -> Result<MangaImage, Box<dyn std::error::Error + Send + Sync>> {
     let url_clone = url.clone();
 
     let start_time = Instant::now();
@@ -38,7 +38,7 @@ async fn async_get_image(url: String, page_no: i32, report: bool) -> Result<Mang
         .unwrap_or("MISS");
 
     let mut cache_state = false; 
-    if (cache == "HIT") {
+    if cache == "HIT" {
         cache_state = true;
     }
 
@@ -48,7 +48,7 @@ async fn async_get_image(url: String, page_no: i32, report: bool) -> Result<Mang
         .unwrap_or("0");
     let content_length = content_length.parse::<usize>().unwrap();
 
-    if (!res.status().is_success() && report) {
+    if !res.status().is_success() && report {
         async_report(url_clone, false, cache_state, content_length, elapsed_time)
             .await?;
         panic!("Failed to retrieve image!"); // TODO: Use ERR or retry instead
@@ -58,7 +58,7 @@ async fn async_get_image(url: String, page_no: i32, report: bool) -> Result<Mang
     let image = image::load_from_memory(&image_bytes)?;
     let image = MangaImage::new(page_no, image);
 
-    if (report) {
+    if report {
         async_report(url_clone, true, cache_state, content_length, elapsed_time).await?;
     }
     
@@ -77,7 +77,7 @@ async fn async_report(url: String, success: bool, cached: bool, bytes: usize, du
         .send()
         .await?;
     
-    if (res.status().as_u16() == 412) {
+    if res.status().as_u16() == 412 {
         let res_headers = res.headers();
         let captcha_ans = res_headers.get("X-Captcha-Sitekey")
             .unwrap()

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,4 +23,4 @@
 
 pub mod connection;
 pub mod manga;
-mod util;
+pub mod util;

--- a/src/manga.rs
+++ b/src/manga.rs
@@ -67,9 +67,11 @@ pub struct Chapter {
 #[derive(Serialize, Deserialize)]
 struct ChapterAttribute {
     #[serde(rename = "chapter")]
-    #[serde(deserialize_with = "util::deserialize_to_f32")]
-    no: f32,
+    #[serde(deserialize_with = "util::deserialize_to_option_f32")]
+    no: Option<f32>,
     pages: i32,
+
+    #[serde(deserialize_with = "util::deserialize_title")]
     title: String
 }
 
@@ -183,7 +185,7 @@ impl AsyncGet for Chapter {}
 impl Chapter {
     /// Returns the chapter number
     pub fn get_chapter_number(&self) -> f32 {
-        self.attributes.no
+        self.attributes.no.unwrap_or(0.0)
     }
 
     /// Returns the number of pages of a chapter

--- a/src/util.rs
+++ b/src/util.rs
@@ -22,3 +22,37 @@ pub fn deserialize_to_f32<'de, D>(deserializer: D) -> Result<f32, D::Error>
     let s: &str = Deserialize::deserialize(deserializer)?;
     f32::from_str(s).map_err(D::Error::custom)
 }
+
+/// A function to help serde parse a string as Option<f32>.
+/// 
+/// # Examples
+/// ```
+/// struct SomeStruct {
+///     #[serde(deserialize_with = "deserialize_to_option_f32")]
+///     float_inside_a_string: Option<f32>,
+/// }
+/// ```
+pub fn deserialize_to_option_f32<'de, D>(deserializer: D) -> Result<Option<f32>, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    let res = Deserialize::deserialize(deserializer)
+        .map(|x: Option<_>| {
+            x.unwrap_or("".to_string())
+        });
+    let res = res.ok();
+    match res {
+        Some(s) => Ok(f32::from_str(&s).ok()),
+        None => Ok(None)
+    }
+}
+
+pub fn deserialize_title<'de, D> (deserializer: D) -> Result<String, D::Error>
+    where
+        D: Deserializer<'de>,
+{
+    Deserialize::deserialize(deserializer)
+        .map(|x: Option<_>| {
+            x.unwrap_or("".to_string())
+        })
+}

--- a/src/util.rs
+++ b/src/util.rs
@@ -47,6 +47,16 @@ pub fn deserialize_to_option_f32<'de, D>(deserializer: D) -> Result<Option<f32>,
     }
 }
 
+/// This function acts as a safe-guard to support when manga chapter titles are null.
+/// Should it be null, it will return an empty string slice instead.
+/// 
+/// # Examples
+/// ```
+/// struct SomeStruct {
+///     #[serde(deserialize_with = "deserialize_title")]
+///     title: String,
+/// }
+/// ```
 pub fn deserialize_title<'de, D> (deserializer: D) -> Result<String, D::Error>
     where
         D: Deserializer<'de>,


### PR DESCRIPTION
Added:
* Added util::deserialize_to_title function
* Added util::deserialize_to_option_f32 function
* A prototype function to report back to MangaDex API report endpoint.
* More Documentation

Modified:
* Changed chapter number data type from f32 to Option<f32>
* Changed the method of the deserialization of chapter title by using the util::deserialize_to_title function

TODO:
* Add functionality to solve Captcha